### PR TITLE
Quiet composer warning re: composer-plugin-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "sculpin/sculpin-theme-composer-plugin",
     "type": "composer-plugin",
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This should take care of these complaints from composer: The "sculpin/sculpin-theme-composer-plugin" plugin requires composer-plugin-api 1.0.0, this _WILL_ break in the future and it should be fixed ASAP (require ^1.0 for example).

It does not appear to break anything in our build, but I have not investigated the impact either.
