### PR TITLE
Add method stubs for uninstall/deactivate to support Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "name": "sculpin/sculpin-theme-composer-plugin",
+    "description": "Plugin for theming sculpin sites",
     "type": "composer-plugin",
     "license": "MIT",
     "require": {
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1|^2.0"
+    },
+    "require-dev": {
+        "composer/composer": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Sculpin/Composer/SculpinThemePlugin/SculpinThemePlugin.php
+++ b/src/Sculpin/Composer/SculpinThemePlugin/SculpinThemePlugin.php
@@ -167,4 +167,14 @@ class SculpinThemePlugin implements PluginInterface, EventSubscriberInterface
 
         $this->filesystem->remove($themeTarget);
     }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // TODO: Implement deactivate() method.
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // TODO: Implement uninstall() method.
+    }
 }


### PR DESCRIPTION
Per https://github.com/sculpin/sculpin/issues/454, things are majorly broken at the moment. This should be a first step to unbreaking them.